### PR TITLE
:zap: Add swagger theme

### DIFF
--- a/lib/writer.js
+++ b/lib/writer.js
@@ -19,10 +19,9 @@ module.exports = function(thorin, opt, baseThemeFn) {
     let themeFn = (typeof _themeFn === 'function' ? _themeFn : baseThemeFn);
     if(!themeFn) return;
     actionCount++;
-    let actionDoc = themeFn(actionObj);
-    if(actionDoc) {
-      FULL_DOC = FULL_DOC + '\n' + actionDoc + '\n';
-    }
+
+    FULL_DOC = themeFn(actionObj);
+
     if(flushTimer) clearTimeout(flushTimer);
     flushTimer = setTimeout(() => {
       writer.flush();

--- a/theme/markdown.js
+++ b/theme/markdown.js
@@ -9,6 +9,8 @@ function capitalize(str) {
 module.exports = function(thorin, opt) {
   const logger = thorin.logger(opt.logger);
 
+  let content = '';
+
   function collectData(result, stack) {
     if(typeof stack !== 'object' || !stack) return;
     for(let i=0; i < stack.length; i++ ){
@@ -62,7 +64,7 @@ module.exports = function(thorin, opt) {
       }
     }
     // check aliases
-    if(action.aliases && action.aliases.length > 0) {
+    if (action.aliases && action.aliases.length > 0) {
       res += '\n##### Aliases \n';
       action.aliases.forEach((alias) => {
         res += '> - ' + alias.verb + ' ' + alias.name + '\n';
@@ -132,6 +134,6 @@ module.exports = function(thorin, opt) {
       res += '\n';
     }
 
-    return res;
-  }
+    return (content += res);
+  };
 };

--- a/theme/swagger.js
+++ b/theme/swagger.js
@@ -1,0 +1,103 @@
+'use strict';
+/**
+ * Created by Niloy on 16-Oct-2022.
+ * This will write to the .json file.
+ */
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.substr(1).toLowerCase();
+}
+module.exports = function (thorin, opt) {
+  const logger = thorin.logger(opt.logger);
+
+  const content = opt.openapi
+    ? {
+        openapi: '3.0.3',
+        info: opt.openapi,
+      }
+    : {};
+
+  content.paths = {};
+
+  let cc = 0;
+
+  function collectData(result, stack) {
+    if (typeof stack !== 'object' || !stack) return;
+    for (let i = 0; i < stack.length; i++) {
+      let item = stack[i];
+      switch (item.type) {
+        case 'validate':
+          result.input.push(item.value);
+          break;
+        case 'authorize':
+          result.authorization.push(item.name);
+          let auth = thorin.dispatcher.getAuthorization(item.name);
+          if (auth) {
+            collectData(result, auth.stack);
+            let validators = auth.validate;
+            for (let j = 0; j < validators.length; j++) {
+              let validator = validators[j];
+              result.input.push(validator);
+            }
+          }
+          break;
+        case 'middleware':
+          result.middleware.push(item.name);
+          let mid = thorin.dispatcher.getMiddleware(item.name);
+          if (mid) {
+            collectData(result, mid.stack);
+            let validators = mid.validate;
+            for (let j = 0; j < validators.length; j++) {
+              let validator = validators[j];
+              result.input.push(validator);
+            }
+          }
+          break;
+      }
+    }
+  }
+
+  return function writeMarkdown(action) {
+    // check inputs & authorizations.
+    let result = {
+      input: [],
+      authorization: [],
+      middleware: [],
+    };
+    // Get the API data
+    collectData(result, action.stack);
+
+    const alias = action.aliases[0];
+
+    const input = [];
+
+    result.input.forEach((each) => {
+      input.push(
+        Object.entries(each).map(([key, value]) => {
+          const defaultError = value.error(),
+            defaultValue = value.default();
+
+          return {
+            name: key,
+            in: 'path',
+            required: true,
+            schema: {
+              type: value.type.toLowerCase(),
+            },
+          };
+        })
+      );
+    });
+
+    if (alias)
+      content.paths = Object.assign(content.paths, {
+        [alias.name]: {
+          [alias.verb.toLowerCase()]: {
+            summary: action.name,
+            parameters: input?.flat(),
+          },
+        },
+      });
+
+    return JSON.stringify(content, null, 4);
+  };
+};


### PR DESCRIPTION
## Added swagger theme

it will generate a JSON file following `openapi` spec partially. The JSON file can be used in `swagger-ui`, `redoc`, `postman` etc. 

### [IMPORTANT] Currently it supports only HTTP aliases of Thorin, without the alias it won't be included in the JSON doc but it will continue supported by the markdown theme. 

> Some parts of `openapi` spec are missing, 

### Changed the `writer.js`
To control the concatenation/post-process of the actions via theme file because for `JSON` we can't use the same method as contacting a string.


### Changed the `markdown.js`  template
To handle the concatenation of strings.


